### PR TITLE
Fixed name of function to convert to php value

### DIFF
--- a/src/Doctrine/Types/GeometryType.php
+++ b/src/Doctrine/Types/GeometryType.php
@@ -100,7 +100,7 @@ class GeometryType extends Type
      */
     public function convertToPHPValueSQL($sqlExpr, $platform)
     {
-        return sprintf('ST_AsWkb(%s)', $sqlExpr);
+        return sprintf('ST_AsBinary(%s)', $sqlExpr);
     }
 
     /**


### PR DESCRIPTION
According to the postgis documentation (http://postgis.net/docs/reference.html) there is no function st_aswkb. The correct name is st_asbinary