### PR TITLE
Convert stream to string

### DIFF
--- a/src/Doctrine/Types/GeometryType.php
+++ b/src/Doctrine/Types/GeometryType.php
@@ -58,7 +58,7 @@ class GeometryType extends Type
             return null;
         }
 
-        return $this->createGeometryProxy($value);
+        return $this->createGeometryProxy(stream_get_contents($value));
     }
 
     /**


### PR DESCRIPTION
The binary data is returned as resource by PDO and needs to be converted to a string before it can be processed.