### PR TITLE
Convert stream to string

### DIFF
--- a/src/Engine/DatabaseEngine.php
+++ b/src/Engine/DatabaseEngine.php
@@ -127,6 +127,10 @@ abstract class DatabaseEngine implements GeometryEngine
     {
         $result = $this->query($function, $parameters, true);
 
+        if (is_resource($result)) {
+            $result = stream_get_contents($result);
+        }
+
         return Geometry::fromBinary($result);
     }
 

--- a/src/IO/WKBBuffer.php
+++ b/src/IO/WKBBuffer.php
@@ -41,10 +41,6 @@ class WKBBuffer
      */
     public function __construct($wkb)
     {
-        if (is_resource($wkb)) {
-            $wkb = stream_get_contents($wkb);
-        }
-
         $this->wkb = $wkb;
         $this->length = strlen($wkb);
         $this->machineByteOrder = WKBTools::getMachineByteOrder();

--- a/src/IO/WKBBuffer.php
+++ b/src/IO/WKBBuffer.php
@@ -41,6 +41,10 @@ class WKBBuffer
      */
     public function __construct($wkb)
     {
+        if (is_resource($wkb)) {
+            $wkb = stream_get_contents($wkb);
+        }
+
         $this->wkb = $wkb;
         $this->length = strlen($wkb);
         $this->machineByteOrder = WKBTools::getMachineByteOrder();


### PR DESCRIPTION
When using PostGIS a stream is returned from the database call. This needs to be converted to a string to be processed by the buffer