### PR TITLE
Add azimuth function

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ This table also shows which functions are part of the OpenGIS standard.
 | Function Name    | GEOS | PostGIS | MySQL  | MariaDB | SpatiaLite | OpenGIS standard |
 |------------------|------|---------|--------|---------|------------|------------------|
 | `area`           |  ✓   |    ✓    |   ✓    |   ✓    |     ✓      |        ✓         |
+| `azimuth`        |      |    ✓    |        |        |            |                  |
 | `boundary`       |  ✓   |    ✓    |        |        |     ✓      |        ✓         |
 | `buffer`         |  ✓   |    ✓    |   ✓    |   ✓    |     ✓      |        ✓         |
 | `centroid`       |  ✓   |    ✓    |   ✓    |   ✓    |     ✓      |        ✓         |

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ This table also shows which functions are part of the OpenGIS standard.
 | Function Name    | GEOS | PostGIS | MySQL  | MariaDB | SpatiaLite | OpenGIS standard |
 |------------------|------|---------|--------|---------|------------|------------------|
 | `area`           |  ✓   |    ✓    |   ✓    |   ✓    |     ✓      |        ✓         |
-| `azimuth`        |      |    ✓    |        |        |            |                  |
+| `azimuth`        |      |    ✓    |        |        |            |        ✓         |
 | `boundary`       |  ✓   |    ✓    |        |        |     ✓      |        ✓         |
 | `buffer`         |  ✓   |    ✓    |   ✓    |   ✓    |     ✓      |        ✓         |
 | `centroid`       |  ✓   |    ✓    |   ✓    |   ✓    |     ✓      |        ✓         |

--- a/src/Doctrine/Functions/AzimuthFunction.php
+++ b/src/Doctrine/Functions/AzimuthFunction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Geo\Doctrine\Functions;
+
+/**
+ * Azimuth() function.
+ */
+class AzimuthFunction extends AbstractFunction
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getSqlFunctionName() : string
+    {
+        return 'ST_Azimuth';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getParameterCount() : int
+    {
+        return 2;
+    }
+}

--- a/src/Engine/DatabaseEngine.php
+++ b/src/Engine/DatabaseEngine.php
@@ -286,9 +286,9 @@ abstract class DatabaseEngine implements GeometryEngine
     /**
      * {@inheritdoc}
      */
-    public function azimuth(Geometry $a, Geometry $b) : float
+    public function azimuth(Geometry $observer, Geometry $subject) : float
     {
-        return $this->queryFloat('ST_Azimuth', $a, $b);
+        return $this->queryFloat('ST_Azimuth', $observer, $subject);
     }
 
     /**

--- a/src/Engine/DatabaseEngine.php
+++ b/src/Engine/DatabaseEngine.php
@@ -286,6 +286,14 @@ abstract class DatabaseEngine implements GeometryEngine
     /**
      * {@inheritdoc}
      */
+    public function azimuth(Geometry $a, Geometry $b) : float
+    {
+        return $this->queryFloat('ST_Azimuth', $a, $b);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function boundary(Geometry $g) : Geometry
     {
         return $this->queryGeometry('ST_Boundary', $g);

--- a/src/Engine/GEOSEngine.php
+++ b/src/Engine/GEOSEngine.php
@@ -174,7 +174,7 @@ class GEOSEngine implements GeometryEngine
     /**
      * {@inheritdoc}
      */
-    public function azimuth(Geometry $a, Geometry $b) : float
+    public function azimuth(Geometry $observer, Geometry $subject) : float
     {
         throw GeometryEngineException::unimplementedMethod(__METHOD__);
     }

--- a/src/Engine/GEOSEngine.php
+++ b/src/Engine/GEOSEngine.php
@@ -174,6 +174,14 @@ class GEOSEngine implements GeometryEngine
     /**
      * {@inheritdoc}
      */
+    public function azimuth(Geometry $a, Geometry $b) : float
+    {
+        throw GeometryEngineException::unimplementedMethod(__METHOD__);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function centroid(Geometry $g) : Geometry
     {
         try {

--- a/src/Engine/GeometryEngine.php
+++ b/src/Engine/GeometryEngine.php
@@ -74,15 +74,15 @@ interface GeometryEngine
      * The azimuth is an angle measured from the north, and is positive clockwise:
      * North = 0; East = π/2; South = π; West = 3π/2.
      *
-     * @param Geometry $a Point representing observer's location.
-     * @param Geometry $b Point representing subject's location.
+     * @param Geometry $observer Point representing observer.
+     * @param Geometry $subject  Point representing subject of observation.
      *
      * @return float Azimuth of the subject relative to the observer.
      *
      * @throws GeometryEngineException If the operation is not supported by the engine.
      * @throws GeometryEngineException If observer and subject locations are coincident.
      */
-    public function azimuth(Geometry $a, Geometry $b) : float;
+    public function azimuth(Geometry $observer, Geometry $subject) : float;
 
     /**
      * Returns the geometric center of a Surface or MultiSurface.

--- a/src/Engine/GeometryEngine.php
+++ b/src/Engine/GeometryEngine.php
@@ -70,6 +70,21 @@ interface GeometryEngine
     public function area(Geometry $g) : float;
 
     /**
+     * Returns the azimuth in radians of the segment defined by the given point geometries.
+     * The azimuth is an angle measured from the north, and is positive clockwise:
+     * North = 0; East = π/2; South = π; West = 3π/2.
+     *
+     * @param Geometry $a Point representing observer's location.
+     * @param Geometry $b Point representing subject's location.
+     *
+     * @return float Azimuth of the subject relative to the observer.
+     *
+     * @throws GeometryEngineException If the operation is not supported by the engine.
+     * @throws GeometryEngineException If observer and subject locations are coincident.
+     */
+    public function azimuth(Geometry $a, Geometry $b) : float;
+
+    /**
      * Returns the geometric center of a Surface or MultiSurface.
      *
      * @param Geometry $g The geometry.

--- a/src/Point.php
+++ b/src/Point.php
@@ -331,9 +331,11 @@ class Point extends Geometry
     }
 
     /**
-     * Calculates the azimuth of the subject relative to the observer (this point).
+     * Returns the azimuth in radians of the segment defined by the given point geometries.
+     * The azimuth is an angle measured from the north, and is positive clockwise:
+     * North = 0; East = π/2; South = π; West = 3π/2.
      *
-     * @param Point $subject Subject's location.
+     * @param Point $subject Point representing subject of observation.
      *
      * @return float
      *

--- a/src/Point.php
+++ b/src/Point.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brick\Geo;
 
+use Brick\Geo\Engine\GeometryEngineRegistry;
 use Brick\Geo\Exception\InvalidGeometryException;
 
 /**
@@ -327,5 +328,20 @@ class Point extends Geometry
     public function getIterator()
     {
         return new \ArrayIterator($this->toArray());
+    }
+
+    /**
+     * Calculates the azimuth of the subject relative to the observer (this point).
+     *
+     * @param Point $subject Subject's location.
+     *
+     * @return float
+     *
+     * @throws GeometryEngineException If the operation is not supported by the engine.
+     * @throws GeometryEngineException If observer and subject locations are coincident.
+     */
+    public function azimuth(Point $subject) : float
+    {
+        return GeometryEngineRegistry::get()->azimuth($this, $subject);
     }
 }

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -3,6 +3,7 @@
 namespace Brick\Geo\Tests;
 
 use Brick\Geo\CoordinateSystem;
+use Brick\Geo\Exception\GeometryEngineException;
 use Brick\Geo\Exception\InvalidGeometryException;
 use Brick\Geo\Point;
 
@@ -253,6 +254,50 @@ class PointTest extends AbstractTestCase
             ['POINT Z (2.3 3.4 4.5)', [2.3, 3.4, 4.5]],
             ['POINT M (3.4 4.5 5.6)', [3.4, 4.5, 5.6]],
             ['POINT ZM (4.5 5.6 6.7 7.8)', [4.5, 5.6, 6.7, 7.8]],
+        ];
+    }
+
+    /**
+     * @dataProvider providerAzimuth
+     *
+     * @param string $observerWkt     The WKT of the point, representing the observer location.
+     * @param string $subjectWkt      The WKT of the point, representing the subject location.
+     * @param array  $azimuthExpected The expected azimuth.
+     *
+     * @return void
+     */
+    public function testAzimuth(string $observerWkt, string $subjectWkt, $azimuthExpected): void
+    {
+        $this->requiresGeometryEngine();
+
+        if ($this->isGEOS() || $this->isMySQL() || $this->isMariaDB() || $this->isSpatiaLite()) {
+            $this->expectException(GeometryEngineException::class);
+        }
+
+        $observer = Point::fromText($observerWkt);
+        $subject = Point::fromText($subjectWkt);
+
+        if ($azimuthExpected === null) {
+            $this->expectException(GeometryEngineException::class);
+        }
+
+        $azimuthActual = $observer->azimuth($subject);
+
+        self::assertEqualsWithDelta($azimuthExpected, $azimuthActual, 0.001);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerAzimuth(): array
+    {
+        return [
+            ['POINT (0 0)', 'POINT (0 0)', null],
+            ['POINT (0 0)', 'POINT (0 1)', 0],
+            ['POINT (0 0)', 'POINT (1 0)', pi() / 2],
+            ['POINT (0 0)', 'POINT (0 -1)', pi()],
+            ['POINT (0 0)', 'POINT (-1 0)', pi() * 3 / 2],
+            ['POINT (0 0)', 'POINT (-0.000001 1)', pi() * 2],
         ];
     }
 }

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -260,17 +260,17 @@ class PointTest extends AbstractTestCase
     /**
      * @dataProvider providerAzimuth
      *
-     * @param string $observerWkt     The WKT of the point, representing the observer location.
-     * @param string $subjectWkt      The WKT of the point, representing the subject location.
-     * @param array  $azimuthExpected The expected azimuth.
+     * @param string $observerWkt         The WKT of the point, representing the observer location.
+     * @param string $subjectWkt          The WKT of the point, representing the subject location.
+     * @param float|null $azimuthExpected The expected azimuth.
      *
      * @return void
      */
-    public function testAzimuth(string $observerWkt, string $subjectWkt, $azimuthExpected): void
+    public function testAzimuth(string $observerWkt, string $subjectWkt, ?float $azimuthExpected): void
     {
         $this->requiresGeometryEngine();
 
-        if ($this->isGEOS() || $this->isMySQL() || $this->isMariaDB() || $this->isSpatiaLite()) {
+        if (! $this->isPostGIS()) {
             $this->expectException(GeometryEngineException::class);
         }
 


### PR DESCRIPTION
Added `azimuth` function implemented by `PostGIS`. 

There are couple of things to discuss:

- [ ] SpatiaLite support. The [docs](http://www.gaia-gis.it/gaia-sins/spatialite-sql-4.2.0.html) say that it's supported but requires some additional modules. Are we going to enable it in the tests?
- [ ] I'm not quite sure about the purpose of the `Brick\Geo\Doctrine\Functions` class hierarchy but added a corresponding class just in case. Could you please clarify this point?
- [ ] Observation `subject` vs `object`. The terminology is tricky here. From the grammar point of view it should be the latter but people most often use the former.