### PR TITLE
Add `GeometryCollection::toSet()` method

### DIFF
--- a/src/GeometryCollection.php
+++ b/src/GeometryCollection.php
@@ -191,18 +191,19 @@ class GeometryCollection extends Geometry
     public function toSet() : GeometryCollection
     {
         $uniqueGeometries = [];
-        $uniqueGeometruesIndex = [];
 
         foreach ($this->geometries as $geometry) {
             $geometryData = $geometry->asBinary();
-            $geometryHash = md5($geometryData, true);
-            if (in_array($geometryHash, $uniqueGeometruesIndex)) {
+            $geometryIsDuplicated = array_key_exists($geometryData, $uniqueGeometries);
+            if ($geometryIsDuplicated) {
                 continue;
             }
 
-            $uniqueGeometries[] = $geometry;
-            $uniqueGeometruesIndex[] = $geometryHash;
+            $uniqueGeometries[$geometryData] = $geometry;
         }
+
+        // The splat operator does not work with string keys (yet).
+        $uniqueGeometries = array_values($uniqueGeometries);
 
         $set = GeometryCollection::of(...$uniqueGeometries);
 

--- a/src/GeometryCollection.php
+++ b/src/GeometryCollection.php
@@ -184,6 +184,32 @@ class GeometryCollection extends Geometry
     }
 
     /**
+     * Returns a new geometry collection containing only unique geometries from the current collection.
+     *
+     * @retrun GeometryCollection
+     */
+    public function toSet() : GeometryCollection
+    {
+        $uniqueGeometries = [];
+        $uniqueGeometruesIndex = [];
+
+        foreach ($this->geometries as $geometry) {
+            $geometryData = $geometry->asBinary();
+            $geometryHash = md5($geometryData, true);
+            if (in_array($geometryHash, $uniqueGeometruesIndex)) {
+                continue;
+            }
+
+            $uniqueGeometries[] = $geometry;
+            $uniqueGeometruesIndex[] = $geometryHash;
+        }
+
+        $set = GeometryCollection::of(...$uniqueGeometries);
+
+        return $set;
+    }
+
+    /**
      * @return Geometry
      */
     public function swapXY() : Geometry

--- a/tests/GeometryCollectionTest.php
+++ b/tests/GeometryCollectionTest.php
@@ -3,6 +3,7 @@
 namespace Brick\Geo\Tests;
 
 use Brick\Geo\Exception\NoSuchGeometryException;
+use Brick\Geo\Geometry;
 use Brick\Geo\GeometryCollection;
 use Brick\Geo\LineString;
 use Brick\Geo\Point;
@@ -99,5 +100,95 @@ class GeometryCollectionTest extends AbstractTestCase
 
         self::assertInstanceOf(\Traversable::class, $geometryCollection);
         self::assertSame([$point, $lineString], iterator_to_array($geometryCollection));
+    }
+
+    /**
+     * @dataProvider providerToSet
+     *
+     * @param Geometry[] $geometries Geometries to initialize the collection with.
+     *
+     * @return void
+     */
+    public function testToSet(array $geometries, int $uniqueGeometriesExpected) : void
+    {
+        $collection = GeometryCollection::of(...$geometries);
+
+        $set = $collection->toSet();
+
+        $uniqueGeometriesActual = $set->numGeometries();
+        $this->assertEquals($uniqueGeometriesExpected, $uniqueGeometriesActual);
+
+        $collectionGeometries = $collection->geometries();
+        $setGeometries = $set->geometries();
+        foreach ($setGeometries as $setGeometry) {
+            $isPresentInOriginalCollection = false;
+
+            foreach ($collectionGeometries as $collectionGeometry) {
+                if ($setGeometry === $collectionGeometry) {
+                    $isPresentInOriginalCollection = true;
+                    break;
+                }
+            }
+
+            $this->assertTrue($isPresentInOriginalCollection);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function providerToSet() : array
+    {
+        return [
+            [
+                [
+                    Point::xy(0, 1),
+                ],
+                1,
+            ],
+            [
+                [
+                    Point::xy(0, 1),
+                    Point::xy(1, 2),
+                ],
+                2,
+            ],
+            [
+                [
+                    Point::xy(0, 1),
+                    Point::xy(0, 1),
+                ],
+                1,
+            ],
+            [
+                [
+                    Point::xy(1, 2),
+                    Point::xy(0, 1),
+                    Point::xy(1, 2),
+                ],
+                2,
+            ],
+            [
+                [
+                    Point::xy(0, 1),
+                    Point::xy(1, 2),
+                    Point::xy(1, 2),
+                    Point::xy(2, 3),
+                ],
+                3,
+            ],
+            [
+                [
+                    Point::xy(1, 2),
+                    Point::xy(0, 1),
+                    Point::xy(1, 2),
+                    Point::xy(1, 2),
+                    Point::xy(1, 2),
+                    Point::xy(2, 3),
+                    Point::xy(1, 2),
+                ],
+                3,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
I'd like to propose to add a functionality of making geometry collections unique.

This is just a quick proof of concept. Maybe the method should be moved to `Geometry`. Maybe it should be named differently. Maybe it should modify the collection instead of creating a new one. Maybe it should be a flag in one of the factory methods. There are really a lot of possible options to implement this...

 I would be glad to hear any comments and/or recommendations.

P.S. Figuring out that splatting gotcha was a nightmare :rofl: 