### PR TITLE
Move `centroid()` to `Geometry`

### DIFF
--- a/src/Geometry.php
+++ b/src/Geometry.php
@@ -339,6 +339,29 @@ abstract class Geometry implements \Countable, \IteratorAggregate
     }
 
     /**
+     * Returns the geometric center of a geometry, or equivalently, the center of mass of the geometry as a Point.
+     * For (Multi)Points, this is computed as the arithmetic mean of the input coordinates.
+     * For (Multi)Linestrings, this is computed as the weighted length of each line segment.
+     * For (Multi)Polygons, "weight" is thought in terms of area.
+     * If an empty geometry is supplied, an empty GeometryCollection is returned.
+     * If CircularString or CompoundCurve are supplied, they are converted to LineString wtih CurveToLine first,
+     * then same than for LineString.
+     *
+     * @noproxy
+     *
+     * @psalm-suppress LessSpecificReturnStatement
+     * @psalm-suppress MoreSpecificReturnType
+     *
+     * @return Point
+     *
+     * @throws GeometryEngineException If the operation is not supported by the geometry engine.
+     */
+    public function centroid() : Point
+    {
+        return GeometryEngineRegistry::get()->centroid($this);
+    }
+
+    /**
      * Returns whether this geometry is spatially equal to another geometry.
      *
      * @noproxy

--- a/src/MultiSurface.php
+++ b/src/MultiSurface.php
@@ -40,25 +40,6 @@ abstract class MultiSurface extends GeometryCollection
     }
 
     /**
-     * Returns the mathematical centroid for this MultiSurface.
-     *
-     * The result is not guaranteed to be on this MultiSurface.
-     *
-     * @noproxy
-     *
-     * @psalm-suppress LessSpecificReturnStatement
-     * @psalm-suppress MoreSpecificReturnType
-     *
-     * @return Point
-     *
-     * @throws GeometryEngineException If the operation is not supported by the geometry engine.
-     */
-    public function centroid() : Point
-    {
-        return GeometryEngineRegistry::get()->centroid($this);
-    }
-
-    /**
      * Returns a Point guaranteed to be on this MultiSurface.
      *
      * @noproxy

--- a/src/Surface.php
+++ b/src/Surface.php
@@ -53,25 +53,6 @@ abstract class Surface extends Geometry
     }
 
     /**
-     * Returns the mathematical centroid for this Surface as a Point.
-     *
-     * The result is not guaranteed to be on this Surface.
-     *
-     * @noproxy
-     *
-     * @psalm-suppress LessSpecificReturnStatement
-     * @psalm-suppress MoreSpecificReturnType
-     *
-     * @return Point
-     *
-     * @throws GeometryEngineException If the operation is not supported by the geometry engine.
-     */
-    public function centroid() : Point
-    {
-        return GeometryEngineRegistry::get()->centroid($this);
-    }
-
-    /**
      * Returns a Point guaranteed to be on this Surface.
      *
      * @noproxy

--- a/tests/GeometryTest.php
+++ b/tests/GeometryTest.php
@@ -547,6 +547,44 @@ class GeometryTest extends AbstractTestCase
     }
 
     /**
+     * @dataProvider providerCentroid
+     *
+     * @param string $geometry    The WKT of the geometry to calculate centroid for.
+     * @param float  $centroidX   Expected `x` coordinate of the geometry centroid.
+     * @param float  $centroidY   Expected `y` coordinate of the geometry centroid.
+     * @param bool   $postgisOnly Whether the test case is supported on `PostGIS` only.
+     *
+     * @return void
+     */
+    public function testCentroid(string $geometry, float $centroidX, float $centroidY, bool $postgisOnly) : void
+    {
+        if ($postgisOnly && !$this->isPostGIS()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $geometry = Geometry::fromText($geometry);
+
+        $centroid = $geometry->centroid();
+
+        $this->assertEqualsWithDelta($centroidX, $centroid->x(), 0.001);
+        $this->assertEqualsWithDelta($centroidY, $centroid->y(), 0.001);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerCentroid() : array
+    {
+        return [
+            ['POINT (42 42)', 42.0, 42.0, true],
+            ['MULTIPOINT (0 0, 1 1)', 0.5, 0.5, true],
+            ['CIRCULARSTRING (1 1, 2 0, -1 1)', 0.0, -1.373, true],
+            ['POLYGON ((0 1, 1 0, 0 -1, -1 0, 0 1))', 0.0, 0.0, false],
+        ];
+    }
+
+    /**
      * @dataProvider providerEquals
      *
      * @param string $geometry1 The WKT of the first geometry.


### PR DESCRIPTION
I was trying to calculate the center between the two points when I realized that `MultiPoint` doesn't support this for some reason. So I decided to fix this. [Reference](https://postgis.net/docs/ST_Centroid.html).

Found out that only `PostGIS` supports all test cases, so I added a special flag.