### PR TITLE
Changing visibility method from private to protected

### DIFF
--- a/src/Engine/DatabaseEngine.php
+++ b/src/Engine/DatabaseEngine.php
@@ -48,7 +48,7 @@ abstract class DatabaseEngine implements GeometryEngine
      *
      * @throws GeometryEngineException
      */
-    private function query(string $function, array $parameters, bool $returnsGeometry) : array
+    protected function query(string $function, array $parameters, bool $returnsGeometry) : array
     {
         $queryParameters = [];
 
@@ -92,7 +92,7 @@ abstract class DatabaseEngine implements GeometryEngine
      *
      * @throws GeometryEngineException
      */
-    private function queryBoolean(string $function, ...$parameters) : bool
+    protected function queryBoolean(string $function, ...$parameters) : bool
     {
         [$result] = $this->query($function, $parameters, false);
 
@@ -117,7 +117,7 @@ abstract class DatabaseEngine implements GeometryEngine
      *
      * @throws GeometryEngineException
      */
-    private function queryFloat(string $function, ...$parameters) : float
+    protected function queryFloat(string $function, ...$parameters) : float
     {
         [$result] = $this->query($function, $parameters, false);
 
@@ -140,7 +140,7 @@ abstract class DatabaseEngine implements GeometryEngine
      *
      * @throws GeometryEngineException
      */
-    private function queryGeometry(string $function, ...$parameters) : Geometry
+    protected function queryGeometry(string $function, ...$parameters) : Geometry
     {
         /** @var array{string|null, string|resource|null, string, int|numeric-string} $result */
         $result = $this->query($function, $parameters, true);
@@ -181,7 +181,7 @@ abstract class DatabaseEngine implements GeometryEngine
      *
      * @throws GeometryEngineException
      */
-    private function getProxyClassName(string $geometryType) : string
+    protected function getProxyClassName(string $geometryType) : string
     {
         $proxyClasses = [
             'CIRCULARSTRING'     => Proxy\CircularStringProxy::class,

--- a/src/Engine/GEOSEngine.php
+++ b/src/Engine/GEOSEngine.php
@@ -79,7 +79,7 @@ class GEOSEngine implements GeometryEngine
      *
      * @return \GEOSGeometry
      */
-    private function toGEOS(Geometry $geometry) : \GEOSGeometry
+    protected function toGEOS(Geometry $geometry) : \GEOSGeometry
     {
         if ($geometry->isEmpty()) {
             $geosGeometry = $this->wktReader->read($geometry->asText());
@@ -100,7 +100,7 @@ class GEOSEngine implements GeometryEngine
      *
      * @return Geometry
      */
-    private function fromGEOS(\GEOSGeometry $geometry) : Geometry
+    protected function fromGEOS(\GEOSGeometry $geometry) : Geometry
     {
         if ($geometry->isEmpty()) {
             return Geometry::fromText($this->wktWriter->write($geometry), $geometry->getSRID());


### PR DESCRIPTION
Hi. I found one problem when switching between different databases.

My code:
```php
GeometryEngineRegistry::set(new PDOEngine($pdo));

$cs = CoordinateSystem::xy(4326);

$polygon = new Polygon($cs, ...[
    new LineString($cs, ...[
        new Point($cs, 0, 0),
        new Point($cs, 0, 1),
        new Point($cs, 1, 1),
        new Point($cs, 1, 0),
        new Point($cs, 0, 0),
    ]),
]);

$area = $polygon->area();
```

A request similar to this is being executed:
```sql
SELECT ST_Area(ST_GeomFromText('POLYGON((0 0,0 1,1 1,1 0,0 0))', 4326));
```
MySQL returns `12308778368.75034` sq meters; PostgreSQL returns `1`

But if I want to get square meters from PostgreSQL, I need to add the `true` parameter to the `ST_Area` function. But this parameter results in an error for MySQL
```sql
SELECT ST_Area(ST_GeomFromText('POLYGON((0 0,0 1,1 1,1 0,0 0))', 4326), true);
```
In this case, PgSQL returns a result very close to MySQL
MySQL:  `12308778368.75034`
PgSQL: `12308778361.469454`

To solve this problem I decided to inherit the class and override the `area` method for PostgreSQL
```php
use Brick\Geo\Engine\PDOEngine;
use Brick\Geo\Geometry;

class PostgreSQLEngine extends PDOEngine
{
    /**
     * @inheritDoc
     */
    public function area(Geometry $g): float
    {
        return $this->queryFloat('ST_Area', $g, true);
    }
}
```
