### PR TITLE
Recognise GEOMCOLLECTION geometry type (MySQL 8)

### DIFF
--- a/src/Engine/DatabaseEngine.php
+++ b/src/Engine/DatabaseEngine.php
@@ -224,7 +224,7 @@ abstract class DatabaseEngine implements GeometryEngine
             'COMPOUNDCURVE'      => Proxy\CompoundCurveProxy::class,
             'CURVE'              => Proxy\CurveProxy::class,
             'CURVEPOLYGON'       => Proxy\CurvePolygonProxy::class,
-            'GEOMCOLLECTION'     => Proxy\GeometryCollectionProxy::class,
+            'GEOMCOLLECTION'     => Proxy\GeometryCollectionProxy::class, /* MySQL 8 - https://github.com/brick/geo/pull/33 */
             'GEOMETRY'           => Proxy\GeometryProxy::class,
             'GEOMETRYCOLLECTION' => Proxy\GeometryCollectionProxy::class,
             'LINESTRING'         => Proxy\LineStringProxy::class,

--- a/src/Engine/DatabaseEngine.php
+++ b/src/Engine/DatabaseEngine.php
@@ -224,6 +224,7 @@ abstract class DatabaseEngine implements GeometryEngine
             'COMPOUNDCURVE'      => Proxy\CompoundCurveProxy::class,
             'CURVE'              => Proxy\CurveProxy::class,
             'CURVEPOLYGON'       => Proxy\CurvePolygonProxy::class,
+            'GEOMCOLLECTION'     => Proxy\GeometryCollectionProxy::class,
             'GEOMETRY'           => Proxy\GeometryProxy::class,
             'GEOMETRYCOLLECTION' => Proxy\GeometryCollectionProxy::class,
             'LINESTRING'         => Proxy\LineStringProxy::class,


### PR DESCRIPTION
We'd been seeing a `Brick\Geo\ExceptionGeometryEngineException` with the message "Unknown geometry type: GEOMCOLLECTION" in our application in some environments.

After a bit of digging, it seems that in MySQL 8, the types `GeometryCollection` and `GeomCollection` can both be used for collections of geometry objects, with `GeomCollection` now being "the preferred type name": https://dev.mysql.com/doc/refman/8.0/en/gis-class-geometrycollection.html

This is a simple to PR to recognise the `GeomCollection ` geometry type in the `getProxyClassName()` method of `\Brick\Geo\Engine\DatabaseEngine` to prevent such exceptions from being thrown.