### PR TITLE
Allow MultiPolygon in GeometryCollection

### DIFF
--- a/src/IO/GeoJSONWriter.php
+++ b/src/IO/GeoJSONWriter.php
@@ -195,7 +195,7 @@ class GeoJSONWriter
         $geometries = $geometryCollection->geometries();
 
         $geometries = array_map(function(Geometry $geometry) {
-            if ($geometry instanceof GeometryCollection) {
+            if (is_a($geometry, 'GeometryCollection')) {
                 throw new GeometryIOException('GeoJSON does not allow nested GeometryCollections.');
             }
 


### PR DESCRIPTION
When trying to write a GeometryCollection with a nested MultiPolygon (or any other geometry that inherits from GeometryCollection), an exception will be raised stating that nested GeometryCollections are not allowed. 

My suggestion would be to use is_a instead of instanceof to allow child classes of GeometryColletion inside a GeometryCollection.