### PR TITLE
PDOEngine - support Mysql ST_GeomFromWKB axis-order option

### DIFF
--- a/src/Engine/MysqlGeoAxisOrder.php
+++ b/src/Engine/MysqlGeoAxisOrder.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Geo\Engine;
+
+/**
+ * @warning Not supported by MariaDB
+ *
+ * @see https://dev.mysql.com/doc/refman/8.0/en/gis-wkb-functions.html
+ */
+enum MysqlGeoAxisOrder: string
+{
+    case SridDefined = 'srid-defined'; // Default
+    case LatLong = 'lat-long';
+    case LongLat = 'long-lat';
+}

--- a/src/Engine/MysqlGeoAxisOrder.php
+++ b/src/Engine/MysqlGeoAxisOrder.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Brick\Geo\Engine;
 
 /**
- * @warning Not supported by MariaDB
- *
  * @see https://dev.mysql.com/doc/refman/8.0/en/gis-wkb-functions.html
+ *
+ * @warning Not supported by MariaDB
  */
 enum MysqlGeoAxisOrder: string
 {

--- a/src/Engine/PdoEngine.php
+++ b/src/Engine/PdoEngine.php
@@ -13,6 +13,7 @@ use PDOStatement;
 use function assert;
 use function is_bool;
 use function is_int;
+use function is_null;
 
 /**
  * Database engine based on a PDO driver.

--- a/src/Engine/PdoEngine.php
+++ b/src/Engine/PdoEngine.php
@@ -31,11 +31,17 @@ final class PdoEngine extends DatabaseEngine
      */
     private array $statements = [];
 
-    public function __construct(PDO $pdo, bool $useProxy = true)
+    private readonly ?MysqlGeoAxisOrder $mysqlGeoAxisOrder;
+
+    /**
+     * @warning MysqlGeoAxisOrder is not supported by MariaDB
+     */
+    public function __construct(PDO $pdo, bool $useProxy = true, ?MysqlGeoAxisOrder $mysqlGeoAxisOrder = null)
     {
         parent::__construct($useProxy);
 
         $this->pdo = $pdo;
+        $this->mysqlGeoAxisOrder = $mysqlGeoAxisOrder;
     }
 
     public function getPDO(): PDO
@@ -93,7 +99,11 @@ final class PdoEngine extends DatabaseEngine
     protected function getGeomFromWkbSyntax(): string
     {
         if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql') {
-            return 'ST_GeomFromWKB(BINARY ?, ?)';
+            if (is_null($this->mysqlGeoAxisOrder)) {
+                return 'ST_GeomFromWKB(BINARY ?, ?)';
+            }
+
+            return "ST_GeomFromWKB(BINARY ?, ?, 'axis-order={$this->mysqlGeoAxisOrder->value}')";
         }
 
         return parent::getGeomFromWkbSyntax();

--- a/tests/PdoEngineMysqlAxisOrderTest.php
+++ b/tests/PdoEngineMysqlAxisOrderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Geo\Tests;
+
+use Brick\Geo\Engine\MysqlGeoAxisOrder;
+use Brick\Geo\Engine\PdoEngine;
+use Brick\Geo\Point;
+use PDO;
+
+use function strpos;
+
+/**
+ * Tests for the MySQL axis-order option of PdoEngine.
+ */
+class PdoEngineMysqlAxisOrderTest extends AbstractTestCase
+{
+    /**
+     * WGS 84: a geographic SRS whose EPSG-defined axis order is latitude-longitude.
+     */
+    private const SRID_WGS84 = 4326;
+
+    public function test_long_lat_and_lat_long_produce_different_results(): void
+    {
+        $pdo = $this->getMysqlPdo();
+
+        $madrid = Point::xy(-3.7, 40.4, self::SRID_WGS84);
+        $paris = Point::xy(2.35, 48.85, self::SRID_WGS84);
+
+        $longLatEngine = new PdoEngine($pdo, useProxy: false, mysqlGeoAxisOrder: MysqlGeoAxisOrder::LongLat);
+        $latLongEngine = new PdoEngine($pdo, useProxy: false, mysqlGeoAxisOrder: MysqlGeoAxisOrder::LatLong);
+
+        $longLatDistance = $longLatEngine->distance($madrid, $paris);
+        $latLongDistance = $latLongEngine->distance($madrid, $paris);
+
+        self::assertNotEqualsWithDelta($longLatDistance, $latLongDistance, 1.0);
+    }
+
+    public function test_srid_defined_matches_lat_long_for_wgs84(): void
+    {
+        $pdo = $this->getMysqlPdo();
+
+        $madrid = Point::xy(-3.7, 40.4, self::SRID_WGS84);
+        $paris = Point::xy(2.35, 48.85, self::SRID_WGS84);
+
+        $latLongEngine = new PdoEngine($pdo, useProxy: false, mysqlGeoAxisOrder: MysqlGeoAxisOrder::LatLong);
+        $sridDefinedEngine = new PdoEngine($pdo, useProxy: false, mysqlGeoAxisOrder: MysqlGeoAxisOrder::SridDefined);
+
+        $latLongDistance = $latLongEngine->distance($madrid, $paris);
+        $sridDefinedDistance = $sridDefinedEngine->distance($madrid, $paris);
+
+        self::assertEqualsWithDelta($latLongDistance, $sridDefinedDistance, 0.001);
+    }
+
+    public function test_axis_order_has_no_effect_on_cartesian_srid(): void
+    {
+        $pdo = $this->getMysqlPdo();
+
+        $engine = new PdoEngine($pdo, useProxy: false, mysqlGeoAxisOrder: MysqlGeoAxisOrder::LatLong);
+
+        $point = Point::xy(10.0, 20.0);
+        $centroid = $engine->centroid($point);
+
+        self::assertPointXyEquals(10.0, 20.0, 0, $centroid);
+    }
+
+    private function getMysqlPdo(): PDO
+    {
+        $engine = $GLOBALS['GEOMETRY_ENGINE'] ?? null;
+
+        if (! $engine instanceof PdoEngine) {
+            self::markTestSkipped('This test requires the pdo_mysql geometry engine.');
+        }
+
+        $pdo = $engine->getPDO();
+
+        if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'mysql') {
+            self::markTestSkipped('This test requires the pdo_mysql geometry engine.');
+        }
+
+        $version = $pdo->query('SELECT VERSION()');
+
+        if ($version === false) {
+            self::markTestSkipped('SELECT VERSION() to determine Mysql vs MariaDB failed');
+        }
+
+        $version = (string) $version->fetchColumn();
+
+        if (strpos($version, '-MariaDB') !== false) {
+            self::markTestSkipped('MariaDB does not support the axis-order option of ST_GeomFromWKB().');
+        }
+
+        return $pdo;
+    }
+}


### PR DESCRIPTION
First: Thank you for this package. This has made the GeoJSON parsing I've had to do a lot quicker and easier!
***
## Problem
Whilst working with an API that only allows Long-Lat axis orders in their GeoJSON I had quite some exceptions as Mysql's default does not accept this as input.

I currently resolved this by making a copy of PDOEngine (since it's final), and adding the option. Though this seems like something that could just be part of the PDOEngine, thus this PR.

I looked through issues and pull requests on a limited amount of keywords and found no matches regarding this.

## Changes
- An optional third parameter `mysqlGeoAxisOrder` added to PdoEngine defaulting to null
  - When set it is passed to `ST_GeomFromWKB` according to MySQL's documentation (linked below)
  - It defaults to null, and not to the MySQL default to ensure there are no changes for any existing implementation, and thus this PR should cause no breaking changes  

I haven't found any resources on MariaDB supporting this, instead of a runtime version check (I found one the tests) and an extra round tip to the driver, I opted to just put warning comments in the code. 

The full test suite including the added ones ran successfully on both MySQL (8.4) and MariaDB (11.4) _(On MariaDB the tests get skipped)_.

**TLDR:** Adds support for the MySQL axis-order options in ST_GeomFromWKB. No breaking changes, one caveat: there is no runtime check for MariaDB, setting this for a MariaDB database will cause an exception.

## Links and Context
I found out about the option [here: https://dev.mysql.com/doc/refman/8.0/en/gis-wkb-functions.html](https://dev.mysql.com/doc/refman/8.0/en/gis-wkb-functions.html)
To quote:
> By default, geographic coordinates (latitude, longitude) are interpreted as in the order specified by the spatial reference system of geometry arguments. An optional options argument may be given to override the default axis order. options consists of a list of comma-separated key=value. The only permitted key value is axis-order, with permitted values of lat-long, long-lat and srid-defined (the default).


## Disclaimers
- Due to my very limited knowledge of GEO/GIS implementations I used AI to provide tests for my changes.
- I figured this might be nice to be included in geo, though I have not spent a lot of time to go through the complete codebase, I might be off on some parts regarding code style.


